### PR TITLE
some improvements

### DIFF
--- a/critbit-test-data.h
+++ b/critbit-test-data.h
@@ -1999,5 +1999,6 @@ const char *test_data[] = {
 "tiUnrohivEvCoatMif",
 "cipoyraryec7",
 "idutcygDo",
+0
 };
 

--- a/critbit-test-tree.h
+++ b/critbit-test-tree.h
@@ -30,7 +30,9 @@
 #ifndef	_SYS_TREE_H_
 #define	_SYS_TREE_H_
 
+#ifdef __FreeBSD__
 #include <sys/cdefs.h>
+#endif
 
 /*
  * This file defines data structures for different types of trees:

--- a/critbit.h
+++ b/critbit.h
@@ -21,7 +21,9 @@
 #define __XCONCAT(x,y)		__XCONCAT1(x,y)
 #endif
 
-__BEGIN_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct critbit_key;
 struct critbit_node;
@@ -168,6 +170,8 @@ name##_critbit_insert((tree), (newnode), (key))
 #define CRITBIT_REMOVE(name, tree, key)					\
 name##_critbit_remove((tree), (key))
 
-__END_DECLS
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
mainly to make it build with musl libc, but also to make msb lookup faster. the method introduced in upstream (link in commit message) is twice as fast as the loop used in original critbit code.
the gnuc version improves upon that by another 10%.